### PR TITLE
https support

### DIFF
--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -28,6 +28,7 @@ type APIClient struct {
 	ctx            context.Context
 	Api            *http.Service     // Beacon Node
 	ELApi          *ethclient.Client // Execution Node
+	bnEndpoint     string
 	Metrics        db.DBMetrics
 	maxRetries     int
 	statesBook     *utils.RoutineBook // Book to track what is being downloaded through the CL API: states
@@ -89,6 +90,7 @@ func NewAPIClient(ctx context.Context, bnEndpoint string, bnApiKey string, cfAcc
 	}
 
 	apiService.Api = hc
+	apiService.bnEndpoint = bnEndpoint
 	apiService.maxRetries = maxRequestRetries
 	for _, o := range options {
 		err := o(apiService)

--- a/pkg/clientapi/rewards.go
+++ b/pkg/clientapi/rewards.go
@@ -3,35 +3,40 @@ package clientapi
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/migalabs/goteth/pkg/spec"
 )
 
 func (s *APIClient) RequestBlockRewards(slot phase0.Slot) (spec.BlockRewards, error) {
+	parsedURL, _ := url.Parse(s.bnEndpoint)
+	parsedURL.Path = fmt.Sprintf("/eth/v1/beacon/rewards/blocks/%d", slot)
 
-	uri := s.Api.Address() + "/eth/v1/beacon/rewards/blocks/" + fmt.Sprintf("%d", slot)
-	resp, err := http.Get(uri)
+	req, _ := http.NewRequestWithContext(s.ctx, http.MethodGet, parsedURL.String(), nil)
+	if parsedURL.User != nil {
+		password, _ := parsedURL.User.Password()
+		req.SetBasicAuth(parsedURL.User.Username(), password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	//We Read the response body on the line below.
-	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	var rewards spec.BlockRewards
-
-	log.Infof("block rewards: %s", string(body))
 	err = json.Unmarshal(body, &rewards)
-
 	if err != nil {
 		log.Fatalf("error parsing block rewards response: %s", err)
 	}
 
 	return rewards, err
-
 }


### PR DESCRIPTION
Rewards.go was not supporting https endpoint only in this file
This fix should help using our nodes running in servers.com or ovh